### PR TITLE
[Feature Fix]Fix project nav wrong color

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -747,6 +747,10 @@ p, a, span {
 
 .osf-project-navbar .navbar-nav li > a:hover {
   background-color: #DADADA; }
+.osf-project-navbar .navbar-nav li > a:focus {
+  background-color: #EEE; }
+.osf-project-navbar .navbar-nav .active > a:focus {
+  background-color: #337AB7; }
 
 .osf-project-navbar li.active,
 .osf-project-navbar li.active a:hover,

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -106,8 +106,16 @@
   font-size: 15px;
 }
 
-.osf-project-navbar .navbar-nav li>a:hover {
-  background-color: #DADADA;
+.osf-project-navbar .navbar-nav {
+  li>a:hover {
+    background-color: #DADADA;
+  }
+  li>a:focus {
+    background-color: #EEE;
+  } 
+  .active > a:focus {
+    background-color: #337AB7;
+  }
 }
 
 .osf-project-navbar li.active,


### PR DESCRIPTION
### Purpose
This PR will solve the issue that when dragging the tab on project navbar, the color of tab will be changed. 

Resolved Trello Issue:
https://trello.com/c/P43cGlKD/45-project-overview-tabs-text-background-changes-but-text-color-does-not-upon-click
### Change
Before Change:
![wrong](https://cloud.githubusercontent.com/assets/5420789/8726250/0bddaf58-2ba7-11e5-8400-55158dda4fbd.gif)

After Change:
![correct](https://cloud.githubusercontent.com/assets/5420789/8726256/12f93f8c-2ba7-11e5-9be0-e89dfd77d132.gif)
