### PR TITLE
Remove Rule About Modal Headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,6 @@
                             <div id="language">
                                 <h4 class="f-w-md"><a></a>Use clear language in our interface</h4>
                                 <p>Where long form text is used it is best to use descriptive language.</p>
-                                <p>All headings should be in title case; all body text should be in sentence case.</p>
                                 <p>Include a period at the end of all full sentences in body text (including instructional and warning text). Headings should not include puncuation.</p>
                                 <p>Good examples:</p>
                                     <div class="osf-box-lt p-lg">


### PR DESCRIPTION
Remove rule about modal headings that states they should be in title case. Issue opened for discussion of this rule: https://github.com/CenterForOpenScience/osf-style/issues/61