### PR TITLE
Fix spelling on dismissible

### DIFF
--- a/style.html
+++ b/style.html
@@ -991,7 +991,7 @@
                             </div>
                             <div class="alert alert-warning alert-dismissible" role="alert">
                                 <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
-                                <strong>Dismissable Alert!</strong> click X to dismiss.
+                                <strong>Dismissible alert!</strong> click X to dismiss.
                             </div>
                         </div>
 


### PR DESCRIPTION
Fixed spelling on dismissible alert.  Also made the word alert lowercase, because alerts appear to all be in sentence case even though not explicitly stated. All the examples above follow this rule. This is not a change.