### PR TITLE
Add guidelines for modal text

### DIFF
--- a/style.html
+++ b/style.html
@@ -965,6 +965,18 @@
     </code>
                         </pre>
 
+                        <h4 class="m-t-lg">Guidelines for Modal Text</h4>
+                        <ul>
+                            <li>Modal titles should generally be clear, concise sentence fragments.</li>
+                            <li>Modal titles should be in sentence case (first letter and proper nouns capitalized).</li>
+                            <li>Modal titles should include question marks (if they are questions), but no other punctuation.</li>
+                            <li>Follow 'Guidelines for Button Text' as shown above.</li>
+                            <li>A user should be able to skip the body of the modal and still understand their general modal options.</li>
+                            <li>Body text should be in full sentences.</li>
+                            <li>These guidelines are modeled after how Google handles “Alerts with title bars.” See <a href="https://www.google.com/design/spec/components/dialogs.html#dialogs-alerts">their guide</a> for examples.</li>
+
+                        </ul>
+
 
                     </div>
                 </div>


### PR DESCRIPTION
This is a proposal for how to solve https://github.com/CenterForOpenScience/osf-style/issues/61.

The biggest change is that modal titles would be in sentence case instead of title case.

Most modal titles would have to be changed in order to match this language convention.