### PR TITLE
[Feature Fix] Refine css for word break 

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -308,9 +308,13 @@ h1, h2, h3, h4, h1 small {
   background-color: #f8f8f8; }
 
 .break-word {
+  word-break: break-word;
+  /* Only WebKit/Blink browsers Support */
   word-wrap: break-word; }
 
-p, a, span {
+p, a, span, em, td {
+  word-break: break-word;
+  /* Only WebKit/Blink browsers Support */
   word-wrap: break-word; }
 
 /*

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -42,9 +42,11 @@ h1, h2, h3, h4, h1 small {
 }
 
 .break-word {
-  word-wrap: break-word;
+  word-break: break-word; /* Only WebKit/Blink browsers Support */
+  word-wrap: break-word ;
 }
 
-p, a, span {
-  word-wrap: break-word;
+p, a, span, em, td {
+  word-break: break-word; /* Only WebKit/Blink browsers Support */
+  word-wrap: break-word ;
 }


### PR DESCRIPTION
Changes:
Apply refined word break to `p, a, span, em, td ` and class `break-word`

      word-break: break-word; /* Only WebKit/Blink browsers Support */
      word-wrap: break-word; }