### PR TITLE
[Feature] Update loading indicators

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,8 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.1"
+  },
+  "devDependencies": {
+    "loaders.css": "^0.1.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,9 +23,9 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.1"
   },
   "devDependencies": {
+    "bootstrap": "~3.3.1",
     "loaders.css": "^0.1.2"
   }
 }

--- a/css/base.css
+++ b/css/base.css
@@ -392,7 +392,6 @@ input {
 
 #navbarScope {
   top: 0px;
-  -webkit-transition: top 0.3s ease-in-out;
   transition: top 0.3s ease-in-out; }
 
 #navbarScope.off {
@@ -410,7 +409,6 @@ input {
   line-height: 1.7; }
 
 .navbar-default {
-  background-image: -webkit-linear-gradient(top, #ffffff 0%, #f8f8f8 100%);
   background-image: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#fff8f8f8', GradientType=0);
@@ -420,7 +418,6 @@ input {
 
 .navbar-default .navbar-nav > .open > a,
 .navbar-default .navbar-nav > .active > a {
-  background-image: -webkit-linear-gradient(top, #dbdbdb 0%, #e2e2e2 100%);
   background-image: linear-gradient(to bottom, #dbdbdb 0%, #e2e2e2 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdbdbdb', endColorstr='#ffe2e2e2', GradientType=0);
@@ -431,7 +428,6 @@ input {
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.25); }
 
 .navbar-inverse {
-  background-image: -webkit-linear-gradient(top, rgba(60, 60, 60, 0.5) 0%, rgba(34, 34, 34, 0.5) 100%);
   background-image: linear-gradient(to bottom, rgba(60, 60, 60, 0.5) 0%, rgba(34, 34, 34, 0.5) 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#803c3c3c', endColorstr='#80222222', GradientType=0);
@@ -440,7 +436,6 @@ input {
 
 .navbar-inverse .navbar-nav > .open > a,
 .navbar-inverse .navbar-nav > .active > a {
-  background-image: -webkit-linear-gradient(top, rgba(8, 8, 8, 0.5) 0%, rgba(15, 15, 15, 0.5) 100%);
   background-image: linear-gradient(to bottom, rgba(8, 8, 8, 0.5) 0%, rgba(15, 15, 15, 0.5) 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80080808', endColorstr='#800f0f0f', GradientType=0);
@@ -594,7 +589,6 @@ input {
     right: auto; } }
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus {
-  background-image: -webkit-linear-gradient(top, #222222 0%, #151515 100%);
   background-image: linear-gradient(to bottom, #222222 0%, #151515 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff222222', endColorstr='#ff151515', GradientType=0);
@@ -603,7 +597,6 @@ input {
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus {
-  background-image: -webkit-linear-gradient(top, #337ab7 0%, #2e6da4 100%);
   background-image: linear-gradient(to bottom, #337ab7 0%, #2e6da4 100%);
   background-repeat: repeat-x;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff337ab7', endColorstr='#ff2e6da4', GradientType=0);
@@ -1005,3 +998,123 @@ input {
 body {
   -webkit-font-smoothing: antialiased;
   font-family: "Open Sans", 'Helvetica Neue', sans-serif !important; }
+
+/**
+ *  Replaces the loaders.css/src/loaders.scss
+ *
+ */
+/**
+ * Styles shared by multiple animations
+ */
+@-webkit-keyframes scale {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 1; }
+  45% {
+    -webkit-transform: scale(0.1);
+            transform: scale(0.1);
+    opacity: 0.7; }
+  80% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 1; } }
+@keyframes scale {
+  0% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 1; }
+  45% {
+    -webkit-transform: scale(0.1);
+            transform: scale(0.1);
+    opacity: 0.7; }
+  80% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 1; } }
+.ball-pulse > div:nth-child(0) {
+  -webkit-animation: scale 0.75s -0.36s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);
+          animation: scale 0.75s -0.36s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); }
+.ball-pulse > div:nth-child(1) {
+  -webkit-animation: scale 0.75s -0.24s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);
+          animation: scale 0.75s -0.24s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); }
+.ball-pulse > div:nth-child(2) {
+  -webkit-animation: scale 0.75s -0.12s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);
+          animation: scale 0.75s -0.12s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); }
+.ball-pulse > div:nth-child(3) {
+  -webkit-animation: scale 0.75s 0s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08);
+          animation: scale 0.75s 0s infinite cubic-bezier(0.2, 0.68, 0.18, 1.08); }
+.ball-pulse > div {
+  background-color: #fff;
+  width: 15px;
+  height: 15px;
+  border-radius: 100%;
+  margin: 2px;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
+  display: inline-block; }
+
+@-webkit-keyframes ball-scale {
+  0% {
+    -webkit-transform: scale(0);
+            transform: scale(0); }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 0; } }
+
+@keyframes ball-scale {
+  0% {
+    -webkit-transform: scale(0);
+            transform: scale(0); }
+  100% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 0; } }
+.ball-scale > div {
+  background-color: #fff;
+  width: 15px;
+  height: 15px;
+  border-radius: 100%;
+  margin: 2px;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
+  display: inline-block;
+  height: 60px;
+  width: 60px;
+  -webkit-animation: ball-scale 1s 0s ease-in-out infinite;
+          animation: ball-scale 1s 0s ease-in-out infinite; }
+
+@-webkit-keyframes ball-beat {
+  50% {
+    opacity: 0.2;
+    -webkit-transform: scale(0.75);
+            transform: scale(0.75); }
+  100% {
+    opacity: 1;
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
+@keyframes ball-beat {
+  50% {
+    opacity: 0.2;
+    -webkit-transform: scale(0.75);
+            transform: scale(0.75); }
+  100% {
+    opacity: 1;
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+.ball-beat > div {
+  background-color: #fff;
+  width: 15px;
+  height: 15px;
+  border-radius: 100%;
+  margin: 2px;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
+  display: inline-block;
+  -webkit-animation: ball-beat 0.7s 0s infinite linear;
+          animation: ball-beat 0.7s 0s infinite linear; }
+  .ball-beat > div:nth-child(2n-1) {
+    -webkit-animation-delay: -0.35s !important;
+            animation-delay: -0.35s !important; }

--- a/css/base.css
+++ b/css/base.css
@@ -1118,3 +1118,6 @@ body {
   .ball-beat > div:nth-child(2n-1) {
     -webkit-animation-delay: -0.35s !important;
             animation-delay: -0.35s !important; }
+
+.ball-dark > div {
+  background-color: #337AB7; }

--- a/css/base.css
+++ b/css/base.css
@@ -1000,8 +1000,8 @@ body {
   font-family: "Open Sans", 'Helvetica Neue', sans-serif !important; }
 
 /**
- *  Replaces the loaders.css/src/loaders.scss
- *
+ *  Replaces the loaders.css/src/loaders.scss which imports animations
+ *  The reason is to import only the animations osf-style needs
  */
 @-webkit-keyframes scale {
   0% {
@@ -1081,40 +1081,6 @@ body {
   width: 60px;
   -webkit-animation: ball-scale 1s 0s ease-in-out infinite;
           animation: ball-scale 1s 0s ease-in-out infinite; }
-
-@-webkit-keyframes ball-beat {
-  50% {
-    opacity: 0.2;
-    -webkit-transform: scale(0.75);
-            transform: scale(0.75); }
-  100% {
-    opacity: 1;
-    -webkit-transform: scale(1);
-            transform: scale(1); } }
-
-@keyframes ball-beat {
-  50% {
-    opacity: 0.2;
-    -webkit-transform: scale(0.75);
-            transform: scale(0.75); }
-  100% {
-    opacity: 1;
-    -webkit-transform: scale(1);
-            transform: scale(1); } }
-.ball-beat > div {
-  background-color: #fff;
-  width: 15px;
-  height: 15px;
-  border-radius: 100%;
-  margin: 2px;
-  -webkit-animation-fill-mode: both;
-          animation-fill-mode: both;
-  display: inline-block;
-  -webkit-animation: ball-beat 0.7s 0s infinite linear;
-          animation: ball-beat 0.7s 0s infinite linear; }
-  .ball-beat > div:nth-child(2n-1) {
-    -webkit-animation-delay: -0.35s !important;
-            animation-delay: -0.35s !important; }
 
 .ball-dark > div {
   background-color: #337AB7; }

--- a/css/base.css
+++ b/css/base.css
@@ -1003,9 +1003,6 @@ body {
  *  Replaces the loaders.css/src/loaders.scss
  *
  */
-/**
- * Styles shared by multiple animations
- */
 @-webkit-keyframes scale {
   0% {
     -webkit-transform: scale(1);
@@ -1121,3 +1118,7 @@ body {
 
 .ball-dark > div {
   background-color: #337AB7; }
+
+/**
+ *  END of loaders
+ */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,10 +22,7 @@ var paths = {
         "./js/script.js"
     ],
     sass : [
-        "sass/*.scss",
-        // "./bower_components/loaders.css/src/*.scss",
-        // "./bower_components/loaders.css/src/animations/*.scss",
-
+        "sass/*.scss"
     ]
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,12 @@ var paths = {
         "./bower_components/bootstrap/dist/js/*.min.js",
         "./js/script.js"
     ],
-    sass : "sass/*.scss"
+    sass : [
+        "sass/*.scss",
+        // "./bower_components/loaders.css/src/*.scss",
+        // "./bower_components/loaders.css/src/animations/*.scss",
+
+    ]
 };
 
 gulp.task('webserver', function() {

--- a/sass/_loader.scss
+++ b/sass/_loader.scss
@@ -1,0 +1,14 @@
+/**
+ *  Replaces the loaders.css/src/loaders.scss
+ *
+ */
+
+/**
+ * Styles shared by multiple animations
+ */
+@import '../bower_components/loaders.css/src/_variables.scss';
+@import '../bower_components/loaders.css/src/mixins';
+
+@import '../bower_components/loaders.css/src/animations/ball-pulse';
+@import '../bower_components/loaders.css/src/animations/ball-scale';
+@import '../bower_components/loaders.css/src/animations/ball-beat';

--- a/sass/_loader.scss
+++ b/sass/_loader.scss
@@ -2,10 +2,6 @@
  *  Replaces the loaders.css/src/loaders.scss
  *
  */
-
-/**
- * Styles shared by multiple animations
- */
 @import '../bower_components/loaders.css/src/_variables.scss';
 @import '../bower_components/loaders.css/src/mixins';
 
@@ -16,3 +12,6 @@
 .ball-dark > div{
     background-color: $color-select;
 }
+/**
+ *  END of loaders
+ */

--- a/sass/_loader.scss
+++ b/sass/_loader.scss
@@ -12,3 +12,7 @@
 @import '../bower_components/loaders.css/src/animations/ball-pulse';
 @import '../bower_components/loaders.css/src/animations/ball-scale';
 @import '../bower_components/loaders.css/src/animations/ball-beat';
+
+.ball-dark > div{
+    background-color: $color-select;
+}

--- a/sass/_loader.scss
+++ b/sass/_loader.scss
@@ -1,13 +1,12 @@
 /**
- *  Replaces the loaders.css/src/loaders.scss
- *
+ *  Replaces the loaders.css/src/loaders.scss which imports animations
+ *  The reason is to import only the animations osf-style needs
  */
 @import '../bower_components/loaders.css/src/_variables.scss';
 @import '../bower_components/loaders.css/src/mixins';
 
 @import '../bower_components/loaders.css/src/animations/ball-pulse';
 @import '../bower_components/loaders.css/src/animations/ball-scale';
-@import '../bower_components/loaders.css/src/animations/ball-beat';
 
 .ball-dark > div{
     background-color: $color-select;

--- a/sass/base.scss
+++ b/sass/base.scss
@@ -1,10 +1,10 @@
-@import '_variables';
-@import '_colors';
-@import '_layout';
-@import '_typography';
-@import '_bootstrap';
-@import '_bootstrap_xl';
-@import '_components';
+@import 'variables';
+@import 'colors';
+@import 'layout';
+@import 'typography';
+@import 'bootstrap';
+@import 'bootstrap_xl';
+@import 'components';
 
 .theme-dropdown .dropdown-menu {
   position: static;
@@ -29,3 +29,5 @@ body {
   -webkit-font-smoothing: antialiased;
   font-family: "Open Sans", 'Helvetica Neue', sans-serif !important;
 }
+
+@import 'loader'; // Custom sass loader for loaders.css library

--- a/style.html
+++ b/style.html
@@ -1373,36 +1373,135 @@
                 </div>
 
                 <hr />
-                <h3 id="loader"> OSF loader </h3>
+                <h3 id="loader"> Loading indicators </h3>
+                <div class="alert alert-warning">Use of OSF logo loader is deprecated but available in this version for backwards compatibility. Please refrain from using osf logo loaders and use one of the options provided below.</div>
+                <p class="p-md">The recommended loading indicators are provided by an external library but bundled in the base.css file for osf-style. Currently these three options are supported, each for either light or dark backgrounds. <p>
+
+
+                <!-- Ball Scale -->
+                <h4>Ball-scale</h4>
+                <p class="p-md">Use for large content and center it horizontally (and vertically depending on container height) <p>
                 <div class="row">
-                    <div class="col-xs-12 m-b-md">
-                        <p> OSF Uses COS logo as a loader gif as shown below in different sizes.   </p>
-                        <div class="logo-spin logo-xs m-r-lg"></div>
-                        <div class="logo-spin logo-sm m-r-lg"></div>
-                        <div class="logo-spin logo-md m-r-lg"></div>
-                        <div class="logo-spin logo-lg m-r-lg"></div>
-                        <div class="logo-spin logo-xl m-r-lg"></div>
+                    <div class="col-xs-6">
+                        <b> Light </b>
+                        <div class="loader bg-color-blue p-lg text-center">
+                            <div class="ball-scale">
+                                <div></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <b> Dark </b>
+                        <div class="loader p-lg">
+                            <div class="ball-scale ball-dark text-center">
+                                <div></div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-sm-12">
-<pre><code class="language-markup">&lt;div class=&quot;logo-spin logo-xs m-r-lg&quot;&gt;&lt;/div&gt;
-&lt;div class=&quot;logo-spin logo-sm m-r-lg&quot;&gt;&lt;/div&gt;
-&lt;div class=&quot;logo-spin logo-md m-r-lg&quot;&gt;&lt;/div&gt;
-&lt;div class=&quot;logo-spin logo-lg m-r-lg&quot;&gt;&lt;/div&gt;
-&lt;div class=&quot;logo-spin logo-xl m-r-lg&quot;&gt;&lt;/div&gt;
+<pre><code class="language-markup">
+    // dark backgrounds
+    &lt;div class=&quot;ball-scale&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+    // light backgrounds
+    &lt;div class=&quot;ball-scale ball-dark&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
 </code></pre>
 
-                        <div class="m-t-md m-b-md p-md osf-box-lt">
-                            <h4 class="text-success"> Tips:</h4>
-                            <ul>
-                                <li> Do not manually change the image sizes, pick an appropriate size.</li>
-                                <li> Do not alter css of the spinners such as speed and animation.</li>
-                                <li> Spinners need to clear when the loading is done or error is received.</li>
-                                <li> The size of the spinner is related to how much space the embedded content holds. I.e. for full page use a large spinner. </li>
-                            </ul>
+                    </div>
+                </div>
+
+
+                <!-- Ball pulse -->
+                <h4 class="m-t-lg">Ball-pulse</h4>
+                <p class="p-md">Use for inline content in place of the element loading. <p>
+                <div class="row">
+                    <div class="col-xs-6">
+                        <b> Light </b>
+                        <div class="loader bg-color-blue p-lg text-center">
+                            <div class="ball-pulse">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
                         </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <b> Dark </b>
+                        <div class="loader p-lg">
+                            <div class="ball-pulse ball-dark text-center">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-12">
+<pre><code class="language-markup">
+    // dark backgrounds
+    &lt;div class=&quot;ball-pulse&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+    // light backgrounds
+    &lt;div class=&quot;ball-pulse ball-dark&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+</code></pre>
+
+                    </div>
+                </div>
+
+
+                <!-- Ball beat -->
+                <h4 class="m-t-lg">Ball-beat</h4>
+                <p class="p-md">Use for inline content in place of the element loading. <p>
+                <div class="row">
+                    <div class="col-xs-6">
+                        <b> Light </b>
+                        <div class="loader bg-color-blue p-lg text-center">
+                            <div class="ball-beat">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-xs-6">
+                        <b> Dark </b>
+                        <div class="loader p-lg">
+                            <div class="ball-beat ball-dark text-center">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-12">
+<pre><code class="language-markup">
+    // dark backgrounds
+    &lt;div class=&quot;ball-beat&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+    // light backgrounds
+    &lt;div class=&quot;ball-beat ball-dark&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+    &lt;/div&gt;
+</code></pre>
+
                     </div>
                 </div>
 
@@ -1762,7 +1861,7 @@
                         <li><a href="#alerts">Alerts</a></li>
                         <li><a href="#navbar">Navigation</a></li>
                         <li><a href="#tabs">Tabs</a></li>
-                        <li><a href="#loader">OSF loader</a></li>
+                        <li><a href="#loader">Loading Indicators</a></li>
                         <li><a href="#progress">Progress bars</a></li>
                         <li><a href="#containers">Containers</a></li>
                         <li><a href="#inputs">Inputs</a></li>

--- a/style.html
+++ b/style.html
@@ -1375,7 +1375,7 @@
                 <hr />
                 <h3 id="loader"> Loading indicators </h3>
                 <div class="alert alert-warning">Use of OSF logo loader is deprecated but available in this version for backwards compatibility. Please refrain from using osf logo loaders and use one of the options provided below.</div>
-                <p class="p-v-md">The recommended loading indicators are provided by an external library (<a href="https://connoratherton.com/loaders" target="_blank"> https://connoratherton.com/loaders</a>) but bundled in the base.css file for osf-style. Currently these three options are supported, each for either light or dark backgrounds. Developers who need more types of loading indicators can add more through a feature Pull Request.<p>
+                <p class="p-v-md">The recommended loading indicators are provided by an external library (<a href="https://connoratherton.com/loaders" target="_blank"> https://connoratherton.com/loaders</a>) but bundled in the base.css file for osf-style. Currently these options are supported, each for either light or dark backgrounds. Developers who need more types of loading indicators can add more through a feature Pull Request.<p>
 
                 <!-- Ball Scale -->
                 <h4>Ball-scale</h4>
@@ -1453,50 +1453,6 @@
 
     // light backgrounds
     &lt;div class=&quot;ball-pulse ball-dark&quot;&gt;
-        &lt;div&gt;&lt;/div&gt;
-    &lt;/div&gt;
-</code></pre>
-
-                    </div>
-                </div>
-
-
-                <!-- Ball beat -->
-                <h4 class="m-t-lg">Ball-beat</h4>
-                <p class="p-md">Use for inline content in place of the element loading. <p>
-                <div class="row">
-                    <div class="col-xs-6">
-                        <b> Light </b>
-                        <div class="loader bg-color-blue p-lg text-center">
-                            <div class="ball-beat">
-                                <div></div>
-                                <div></div>
-                                <div></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-6">
-                        <b> Dark </b>
-                        <div class="loader p-lg">
-                            <div class="ball-beat ball-dark text-center">
-                                <div></div>
-                                <div></div>
-                                <div></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="row">
-                    <div class="col-sm-12">
-<pre><code class="language-markup">
-    // dark backgrounds
-    &lt;div class=&quot;ball-beat&quot;&gt;
-        &lt;div&gt;&lt;/div&gt;
-    &lt;/div&gt;
-
-    // light backgrounds
-    &lt;div class=&quot;ball-beat ball-dark&quot;&gt;
         &lt;div&gt;&lt;/div&gt;
     &lt;/div&gt;
 </code></pre>

--- a/style.html
+++ b/style.html
@@ -1375,8 +1375,7 @@
                 <hr />
                 <h3 id="loader"> Loading indicators </h3>
                 <div class="alert alert-warning">Use of OSF logo loader is deprecated but available in this version for backwards compatibility. Please refrain from using osf logo loaders and use one of the options provided below.</div>
-                <p class="p-md">The recommended loading indicators are provided by an external library but bundled in the base.css file for osf-style. Currently these three options are supported, each for either light or dark backgrounds. <p>
-
+                <p class="p-v-md">The recommended loading indicators are provided by an external library (<a href="https://connoratherton.com/loaders" target="_blank"> https://connoratherton.com/loaders</a>) but bundled in the base.css file for osf-style. Currently these three options are supported, each for either light or dark backgrounds. Developers who need more types of loading indicators can add more through a feature Pull Request.<p>
 
                 <!-- Ball Scale -->
                 <h4>Ball-scale</h4>


### PR DESCRIPTION
## Purpose
Removes the osf logo based spinner to provide more subtle spinners, in this case 3 for different occasions. 

The main reason is that as we move to a single page application with API v2, multiple aspects of the page will be loading data and will need to show loading indicators. Using a logo that appears in multiple places is unattractive. Better visual design and UI would be to include more subtle indicators that can be used in multiple locations.

 
![screen shot 2017-04-19 at 9 46 16 am](https://cloud.githubusercontent.com/assets/1314003/25183767/84d668fc-24e6-11e7-9efc-48649008a8d5.png)
 