### PR TITLE
Go right to index.html when running gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ This project aims to bring together resources to build Design and Layout of OSF 
 
         $ npm install
 
-* Then run gulp script and the project dashboard could be found in `http://localhost:8000/`
+* Run gulp to view the website at `http://localhost:8000/`
 
         $ npm run gulp
-After that, click `index.html` in the list directory and now the guideline page will show in your browser.
 
-With the help of gulp, every change in repo code will automatically be complied and changed after saving.  
+With the help of gulp, every change in repo code will automatically be compiled and changed after saving.  
 
 ### Possible Issues
 * If npm is not installed (`-bash : npm: command not found`), please install [node.js](https://nodejs.org/download/) in which it contains `npm`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,6 @@ gulp.task('webserver', function() {
     gulp.src('./')
         .pipe(webserver({
             livereload: true,
-            directoryListing: true,
             open: true
         }));
 });


### PR DESCRIPTION
Running `npm run gulp` will go directly to index.html rather than a directory listing.