### PR TITLE
Add navbar donate link css [OSF-8348]

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -521,6 +521,10 @@ input {
   line-height: 1.7;
 }
 
+.navbar-donate-button a{
+  color: #9cd59c !important;
+}
+
 .navbar-default {
   background-image: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
   background-repeat: repeat-x;


### PR DESCRIPTION
## Purpose

Navbar CSS should be in a central location. I added CSS to the OSF in `nav.css` for the new navbar donate button in [this PR](https://github.com/CenterForOpenScience/osf.io/pull/7483) and should have done it here instead. 

## Changes

Add the green color for the new navbar donate link here.


## Ticket

https://openscience.atlassian.net/browse/OSF-8348