### PR TITLE
Fix style guidelines for loaders

### DIFF
--- a/style.html
+++ b/style.html
@@ -1408,7 +1408,7 @@
     &lt;/div&gt;
 
     // light backgrounds
-    &lt;div class=&quot;ball-scale ball-dark&quot;&gt;
+    &lt;div class=&quot;ball-scale ball-scale-blue&quot;&gt;
         &lt;div&gt;&lt;/div&gt;
     &lt;/div&gt;
 </code></pre>
@@ -1452,7 +1452,9 @@
     &lt;/div&gt;
 
     // light backgrounds
-    &lt;div class=&quot;ball-pulse ball-dark&quot;&gt;
+    &lt;div class=&quot;ball-pulse ball-scale-blue&quot;&gt;
+        &lt;div&gt;&lt;/div&gt;
+        &lt;div&gt;&lt;/div&gt;
         &lt;div&gt;&lt;/div&gt;
     &lt;/div&gt;
 </code></pre>


### PR DESCRIPTION
On `osf.io/develop` as of submitting this PR, `.ball-dark` will cause loaders to cycle once and then abruptly stop, whereas `.ball-scale-blue`, which is already widely used on the OSF, accomplishes the same color change while allowing the loaders to continue cycling.

Also, `.ball-pulse` requires three empty inner divs, not just one.