### PR TITLE
[IN-368][OSF-Style] Move navbar padding and margin to osf-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Styling from `ember-osf-preprints` to remove preprint word on smaller screens
+
+### Changed
+- Padding and margins on branded navbars to prevent line breaks and overlaps
+
 ## [1.7.0] - 2018-04-12
 ### Changed
 - Navbar to use flexbox instead of floated divs

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -70,6 +70,13 @@
 
 @include opacity-animation(0.1, 1, 0.1,"opacity");
 
+/* Preprints/Registries navbar styling */
+nav.preprint-navbar {
+  .navbar-title {
+    padding-right: 10px;
+  }
+}
+
 /* OSF BOX */
 
 .osf-box {
@@ -158,6 +165,12 @@
   }
   .osf-project-navbar a.project-title {
     max-width: 190px;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-branded-header {
+    margin-right: 20px !important;
   }
 }
 

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -74,6 +74,14 @@
 nav.preprint-navbar {
   .navbar-title {
     padding-right: 10px;
+    display: flex;
+  }
+  @media (max-width: 520px) {
+    .navbar-title > .navbar-title-item {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 }
 
@@ -204,6 +212,7 @@ nav.preprint-navbar {
   .navbar-header {
     float: none;
     width: 100%;
+    display: flex;
   }
   .navbar-toggle {
     display: block;


### PR DESCRIPTION
## Purpose

On branded navbars with long provider names, the hamburger icon will break to another line on small screens.  

## Changes

- Move styling changes from `ember-osf-preprints` to `osf-style`
- Lessoned padding between branded name and the icon
- Increased margin between the branded name and links
- Added flexbox styling and an ellipsis overflow to long brand names on mobile view

## QA Notes

This will affect how the navbar acts on smaller screens.  You should be able to make the screen small and notice that the hamburger menu icon doesn't drop to a lower line with a brand like `LIS Scholarship Archive`.

Even on a navbar with many links you should also notice that the branded name never overlaps any of the links.

On mobile view:
<img width="321" alt="screen shot 2018-09-27 at 2 23 41 pm" src="https://user-images.githubusercontent.com/19379783/46167945-20a57580-c265-11e8-8d0c-83b3b05fa8d2.png">


![demo_gif](https://user-images.githubusercontent.com/19379783/46167916-14211d00-c265-11e8-9a62-2cafd83cdd1a.gif)


## Ticket

https://openscience.atlassian.net/browse/IN-368