### PR TITLE
[EMB-547] Fix navbar spacing

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1485,7 +1485,6 @@ nav.preprint-navbar .navbar-title {
 
 #secondary-navigation {
   float: right;
-  margin-right: 25px;
 }
 
 @media (max-width: 767px) {
@@ -1535,6 +1534,10 @@ nav.preprint-navbar .navbar-title {
   }
 }
 @media (max-width: 992px) {
+  #secondary-navigation {
+    margin-right: 25px;
+  }
+
   #navbarScope div.container {
     width: 100%;
   }

--- a/css/base.css
+++ b/css/base.css
@@ -1483,6 +1483,11 @@ nav.preprint-navbar .navbar-title {
   padding-right: 15px;
 }
 
+#secondary-navigation {
+  float: right;
+  margin-right: 25px;
+}
+
 @media (max-width: 767px) {
   .osf-project-navbar li > a {
     padding-left: 30px;
@@ -1543,6 +1548,7 @@ nav.preprint-navbar .navbar-title {
   }
 
   .navbar-toggle {
+    margin-left: auto;
     display: block;
   }
 

--- a/css/osf-style.css
+++ b/css/osf-style.css
@@ -1483,6 +1483,11 @@ nav.preprint-navbar .navbar-title {
   padding-right: 15px;
 }
 
+#secondary-navigation {
+  float: right;
+  margin-right: 25px;
+}
+
 @media (max-width: 767px) {
   .osf-project-navbar li > a {
     padding-left: 30px;

--- a/css/osf-style.css
+++ b/css/osf-style.css
@@ -1485,7 +1485,6 @@ nav.preprint-navbar .navbar-title {
 
 #secondary-navigation {
   float: right;
-  margin-right: 25px;
 }
 
 @media (max-width: 767px) {
@@ -1535,6 +1534,10 @@ nav.preprint-navbar .navbar-title {
   }
 }
 @media (max-width: 992px) {
+  #secondary-navigation {
+    margin-right: 25px;
+  }
+
   #navbarScope div.container {
     width: 100%;
   }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -159,6 +159,11 @@ nav.preprint-navbar {
   padding-right: 15px;
 }
 
+#secondary-navigation {
+  float: right;
+  margin-right: 25px;
+}
+
 @media (max-width: 767px) {
   .osf-project-navbar li > a {
     padding-left: 30px;
@@ -215,6 +220,7 @@ nav.preprint-navbar {
     display: flex;
   }
   .navbar-toggle {
+    margin-left: auto;
     display: block;
   }
   .navbar-toggle.collapsed {

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -161,7 +161,6 @@ nav.preprint-navbar {
 
 #secondary-navigation {
   float: right;
-  margin-right: 25px;
 }
 
 @media (max-width: 767px) {
@@ -211,6 +210,9 @@ nav.preprint-navbar {
 }
 
 @media (max-width: 992px) {
+  #secondary-navigation {
+    margin-right: 25px;
+  }
   #navbarScope div.container {
     width: 100%;
   }


### PR DESCRIPTION
## Purpose

To fix spacing in the Preprints navbar and to fix alignment of secondary navbar items.

## Changes

- Add `float: right` and `margin-right: 25px` to `#secondary-navigation` to properly align navbar items in smaller screens
- Add `margin-left: auto` to the `.navbar-toggle` to fix alignment

![screen shot 2019-02-27 at 11 32 38 am](https://user-images.githubusercontent.com/19379783/53506186-7041d480-3a83-11e9-934c-72f18d9325cf.png)


## Ticket

https://openscience.atlassian.net/browse/EMB-547